### PR TITLE
feat(compodoc): add --unitTestCoverage flag support

### DIFF
--- a/libs/compodoc/src/builders/compodoc/compodoc-utils.ts
+++ b/libs/compodoc/src/builders/compodoc/compodoc-utils.ts
@@ -174,5 +174,10 @@ export function buildCompodocArgs(
     args.push('--silent');
   }
 
+  if (options.unitTestCoverage) {
+    const coveragePath = resolve(workspaceRoot, options.unitTestCoverage);
+    args.push(`--unitTestCoverage=${coveragePath}`);
+  }
+
   return args;
 }

--- a/libs/compodoc/src/builders/compodoc/schema.d.ts
+++ b/libs/compodoc/src/builders/compodoc/schema.d.ts
@@ -55,4 +55,6 @@ export interface CompodocBuilderSchema extends JsonObject {
   port: number;
 
   silent: boolean;
+
+  unitTestCoverage?: string;
 }

--- a/libs/compodoc/src/builders/compodoc/schema.json
+++ b/libs/compodoc/src/builders/compodoc/schema.json
@@ -192,6 +192,11 @@
       "description": "Suppress verbose build output.",
       "type": "boolean",
       "default": true
+    },
+
+    "unitTestCoverage": {
+      "description": "To include unit test coverage, specify istanbul JSON coverage summary file",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
Adds `unitTestCoverage` option to the builder's options object. Updated related interfaces as well as builder schema with same text as is in the official compodoc documentation.

Closes #12 