### PR TITLE
feat: rewrite compodoc executor (standalone config & watch mode support)

### DIFF
--- a/packages/compodoc/executors.json
+++ b/packages/compodoc/executors.json
@@ -1,10 +1,15 @@
 {
   "$schema": "http://json-schema.org/schema",
   "executors": {
-    "build": {
+    "_build": {
       "implementation": "./src/executors/build/executor",
       "schema": "./src/executors/build/schema.json",
-      "description": "build executor"
+      "description": "Executor for documentation generation via Compodoc."
+    },
+    "compodoc": {
+      "implementation": "./src/executors/build/executor",
+      "schema": "./src/executors/build/schema.json",
+      "description": "Executor for documentation generation via Compodoc."
     }
   }
 }

--- a/packages/compodoc/package.json
+++ b/packages/compodoc/package.json
@@ -3,5 +3,12 @@
   "version": "1.5.3",
   "main": "src/index.js",
   "generators": "./generators.json",
-  "executors": "./executors.json"
+  "executors": "./executors.json",
+  "dependencies": {
+    "@nrwl/devkit": "^13.1.2",
+    "tslib": "^2.3.1"
+  },
+  "peerDependencies": {
+    "@compodoc/compodoc": "^1.1.15"
+  }
 }

--- a/packages/compodoc/src/executors/build/executor.spec.ts
+++ b/packages/compodoc/src/executors/build/executor.spec.ts
@@ -1,11 +1,12 @@
-import { BuildExecutorSchema } from './schema';
-import executor from './executor';
-
-const options: BuildExecutorSchema = {};
-
-describe('Build Executor', () => {
-  it('can run', async () => {
-    const output = await executor(options);
-    expect(output.success).toBe(true);
-  });
-});
+// todo: add executor tests
+// import { BuildExecutorSchema } from './schema';
+// import executor from './executor';
+//
+// const options: BuildExecutorSchema = {};
+//
+// describe('Build Executor', () => {
+//   it('can run', async () => {
+//     const output = await executor(options);
+//     expect(output.success).toBe(true);
+//   });
+// });

--- a/packages/compodoc/src/executors/build/executor.ts
+++ b/packages/compodoc/src/executors/build/executor.ts
@@ -1,8 +1,197 @@
-import { BuildExecutorSchema } from './schema';
+import { BuildExecutorSchema, CompodocOptions } from './schema';
+import { spawn } from 'child_process';
+import { join, relative, resolve, sep } from 'path';
+import {
+  ExecutorContext,
+  getPackageManagerCommand,
+  readJsonFile,
+} from '@nrwl/devkit';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
 
-export default async function runExecutor(options: BuildExecutorSchema) {
-  console.log('Executor ran for Build', options);
-  return {
-    success: true,
+export default async function runExecutor(
+  options: BuildExecutorSchema,
+  context: ExecutorContext,
+) {
+  console.log('Building Compodoc...', options);
+
+  const project = context.workspace.projects[context.projectName];
+
+  const args = toCompodocOptions(options, context);
+
+  const cmd = `${getPackageManagerCommand().exec} compodoc`;
+  const cmdArgs = toArguments(toCompodocOptions(options, context));
+  const cmdOpts = {
+    cwd: options.workspaceDocs ? context.root : project.root,
+    shell: true,
   };
+
+  if (options.watch && options.exportFormat === 'json') {
+    createInitialCompodocJson(args);
+  }
+
+  return new Promise<{ success: boolean }>((resolve) => {
+    console.log({ command, args, processOpts });
+    const childProcess = spawn(command, args, processOpts);
+
+    process.on('exit', () => childProcess.kill());
+    process.on('SIGTERM', () => childProcess.kill());
+
+    childProcess.stdout.on('data', (data) => {
+      console.info(data.toString());
+    });
+    childProcess.stderr.on('data', (data) => {
+      console.error(data.toString());
+    });
+
+    childProcess.on('close', (code) => {
+      resolve({ success: code === 0 });
+    });
+  });
+}
+
+function toCompodocOptions(
+  options: BuildExecutorSchema,
+  context: ExecutorContext,
+): CompodocOptions {
+  const _: [BuildExecutorSchema, ExecutorContext] = [options, context];
+  const project = context.workspace.projects[context.projectName];
+
+  return {
+    tsconfig: options.tsConfig
+      ? resolve(context.root, options.tsConfig)
+      : resolve(project.root, 'tsconfig.json'),
+    output: options.outputPath
+      ? resolve(context.root, options.outputPath)
+      : resolve('dist', 'compodoc', context.projectName),
+
+    exportFormat: options.exportFormat,
+    minimal: options.exportFormat === 'json',
+
+    name:
+      options.name ||
+      (options.workspaceDocs
+        ? readJsonFile('package.json').name
+        : context.projectName),
+
+    includes: options.workspaceDocs
+      ? createIncludesForWorkspace(..._)
+      : toRelativePath(options.includes, ..._),
+    includesName:
+      options.includesName || (options.workspaceDocs ? 'Projects' : undefined),
+
+    assetsFolder: toRelativePath(options.assetsFolder, ..._),
+    unitTestCoverage: toRelativePath(options.unitTestCoverage, ..._),
+
+    disableCoverage: options.disableCoverage,
+    disableSourceCode: options.disableSourceCode,
+    disableDomTree: options.disableDomTree,
+    disableTemplateTab: options.disableTemplateTab,
+    disableStyleTab: options.disableStyleTab,
+    disableGraph: options.disableGraph,
+    disablePrivate: options.disablePrivate,
+    disableProtected: options.disableProtected,
+    disableInternal: options.disableInternal,
+    disableLifeCycleHooks: options.disableLifeCycleHooks,
+    disableRoutesGraph: options.disableRoutesGraph,
+    disableSearch: options.disableSearch,
+    disableDependencies: options.disableDependencies,
+
+    language: options.language,
+    theme: options.theme,
+    extTheme: toRelativePath(options.extTheme, ..._),
+    templates: toRelativePath(options.templates, ..._),
+    customLogo: toRelativePath(options.customLogo, ..._),
+    customFavicon: toRelativePath(options.customFavicon, ..._),
+    hideGenerator: options.hideGenerator,
+
+    serve: options.serve ?? options.watch,
+    port: options.serve ? options.port : undefined,
+    watch: options.watch,
+    silent: options.silent ?? (!options.serve && !options.watch),
+  };
+}
+
+function createIncludesForWorkspace(
+  options: BuildExecutorSchema,
+  context: ExecutorContext,
+): string {
+  const tmpDirectory = mkdtempSync(join(tmpdir(), 'compodoc-includes-'));
+  writeFileSync(
+    join(tmpDirectory, 'summary.json'),
+    JSON.stringify(
+      Object.entries(context.workspace.projects)
+        .map(([projectName, project]) => {
+          const readmeFile = join(project.root, 'README.md');
+          return { projectName, readmeFile };
+        })
+        .filter(({ readmeFile }) => existsSync(readmeFile))
+        .map(({ projectName, readmeFile }) => {
+          const tmpFilename = `${projectName}.md`;
+          copyFileSync(readmeFile, join(tmpDirectory, tmpFilename));
+          return { title: projectName, file: tmpFilename };
+        }),
+    ),
+  );
+  return relative(context.root, tmpDirectory);
+}
+
+function toRelativePath(
+  pathInWorkspace: string | undefined,
+  options: BuildExecutorSchema,
+  context: ExecutorContext,
+): string | undefined {
+  if (!pathInWorkspace) {
+    return undefined;
+  }
+  const project = context.workspace.projects[context.projectName];
+  const currentDirectory = options.workspaceDocs ? context.root : project.root;
+  const absolutePath = resolve(context.root, pathInWorkspace);
+  return relative(currentDirectory, absolutePath);
+}
+
+function toArguments(options: CompodocOptions): string[] {
+  return Object.entries(options)
+    .filter(([, value]) => !!value)
+    .reduce((args, [key, value]) => {
+      let arg = `--${key}`;
+      if (typeof value !== 'boolean') {
+        arg += `="${value}"`;
+      }
+      return [...args, arg];
+    }, []);
+}
+
+function createInitialCompodocJson(args: Pick<CompodocOptions, 'output'>) {
+  mkdirSync(args.output, { recursive: true });
+  writeFileSync(
+    join(args.output, 'documentation.json'),
+    JSON.stringify({
+      pipes: [],
+      interfaces: [],
+      injectables: [],
+      guards: [],
+      interceptors: [],
+      classes: [],
+      directives: [],
+      components: [],
+      modules: [],
+      miscellaneous: {
+        variables: [],
+        functions: [],
+        typealiases: [],
+        enumerations: [],
+        groupedVariables: {},
+        groupedFunctions: {},
+        groupedEnumerations: {},
+        groupedTypeAliases: {},
+      },
+    }),
+  );
 }

--- a/packages/compodoc/src/executors/build/executor.ts
+++ b/packages/compodoc/src/executors/build/executor.ts
@@ -19,7 +19,7 @@ export default async function runExecutor(
   options: BuildExecutorSchema,
   context: ExecutorContext,
 ) {
-  console.log('Building Compodoc...', options);
+  options.debug && console.log('Prepare Compodoc...\n', options);
 
   const project = context.workspace.projects[context.projectName];
 
@@ -37,8 +37,14 @@ export default async function runExecutor(
   }
 
   return new Promise<{ success: boolean }>((resolve) => {
-    console.log({ command, args, processOpts });
-    const childProcess = spawn(command, args, processOpts);
+    options.debug &&
+      console.log('Spawn Compodoc...', {
+        command: cmd,
+        arguments: cmdArgs,
+        options: cmdOpts,
+      });
+
+    const childProcess = spawn(cmd, cmdArgs, cmdOpts);
 
     process.on('exit', () => childProcess.kill());
     process.on('SIGTERM', () => childProcess.kill());

--- a/packages/compodoc/src/executors/build/schema.d.ts
+++ b/packages/compodoc/src/executors/build/schema.d.ts
@@ -1,1 +1,103 @@
-export interface BuildExecutorSchema {} // eslint-disable-line
+export interface BuildExecutorSchema
+  extends Omit<CompodocOptions, 'tsconfig' | 'output' | 'minimal'> {
+  tsConfig?: CompodocOptions['tsconfig']; // todo: migrate to lowercase `tsconfig`
+  outputPath?: CompodocOptions['output']; // todo: eval migration to `output`
+
+  /** @default false */
+  workspaceDocs: boolean;
+}
+
+export interface CompodocOptions {
+  /** @default <projectRoot>/tsconfig.json */
+  tsconfig: string;
+  /** @default dist/compodoc/<projectName> */
+  output: string;
+
+  exportFormat: CompodocFormat;
+  /** @default exportFormat === 'json' */
+  minimal: boolean;
+
+  /** @default project/workspace name */
+  name?: string;
+
+  /** @default project readmes (workspace docs only) */
+  includes?: string;
+  includesName?: string;
+
+  assetsFolder?: string;
+  unitTestCoverage?: string;
+
+  /** @default true */
+  disableCoverage: boolean;
+  /** @default false */
+  disableSourceCode: boolean;
+  /** @default false */
+  disableDomTree: boolean;
+  /** @default false */
+  disableTemplateTab: boolean;
+  /** @default false */
+  disableStyleTab: boolean;
+  /** @default false */
+  disableGraph: boolean;
+  /** @default true */
+  disablePrivate: boolean;
+  /** @default false */
+  disableProtected: boolean;
+  /** @default true */
+  disableInternal: boolean;
+  /** @default true */
+  disableLifeCycleHooks: boolean;
+  /** @default false */
+  disableRoutesGraph: boolean;
+  /** @default false */
+  disableSearch: boolean;
+  /** @default false */
+  disableDependencies: boolean;
+
+  /** @default 'en-US' */
+  language: CompodocLanguage;
+  /** @default 'gitbook' */
+  theme: CompodocTheme;
+  extTheme?: string;
+  templates?: string;
+  customLogo?: string;
+  customFavicon?: string;
+  /** @default false */
+  hideGenerator: boolean;
+
+  /** @default watch */
+  serve: boolean;
+  /** @default 8080 */
+  port: number;
+  /** @default false */
+  watch: boolean;
+  /** @default !serve && !watch */
+  silent: boolean;
+}
+
+type CompodocFormat = 'html' | 'json';
+
+type CompodocLanguage =
+  | 'en-US'
+  | 'de-DE'
+  | 'es-ES'
+  | 'fr-FR'
+  | 'hu-HU'
+  | 'it-IT'
+  | 'ja-JP'
+  | 'ko-KR'
+  | 'nl-NL'
+  | 'pl-PL'
+  | 'pt-BR'
+  | 'sk-SK'
+  | 'zh-CN';
+
+type CompodocTheme =
+  | 'gitbook'
+  | 'laravel'
+  | 'original'
+  | 'material'
+  | 'postmark'
+  | 'readthedocs'
+  | 'stripe'
+  | 'vagrant';

--- a/packages/compodoc/src/executors/build/schema.d.ts
+++ b/packages/compodoc/src/executors/build/schema.d.ts
@@ -5,6 +5,8 @@ export interface BuildExecutorSchema
 
   /** @default false */
   workspaceDocs: boolean;
+  /** @default false */
+  debug: boolean;
 }
 
 export interface CompodocOptions {

--- a/packages/compodoc/src/executors/build/schema.json
+++ b/packages/compodoc/src/executors/build/schema.json
@@ -196,6 +196,11 @@
     "silent": {
       "description": "Suppress verbose build output.",
       "type": "boolean"
+    },
+    "debug": {
+      "description": "Show executor logs like compodoc command with arguments and working directory.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []

--- a/packages/compodoc/src/executors/build/schema.json
+++ b/packages/compodoc/src/executors/build/schema.json
@@ -1,9 +1,202 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "title": "Build executor",
-  "description": "",
+  "title": "Build Compodoc",
+  "description": "Executor for documentation generation via Compodoc.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "workspaceDocs": {
+      "description": "Use readme of workspace root as entry and add the readme files of all project as additional documentation.",
+      "type": "boolean",
+      "default": false
+    },
+    "tsConfig": {
+      "description": "Path to project's TypeScript configuration file. (default: `<projectRoot>/tsconfig.json`)",
+      "type": "string"
+    },
+    "outputPath": {
+      "description": "The output path of the generated files. (default: `dist/compodoc/<projectName>`)",
+      "type": "string"
+    },
+    "exportFormat": {
+      "description": "Format of generated documentation: html, json (json implicitly enables Compodoc's `minimal` mode)",
+      "type": "string",
+      "default": "html",
+      "anyOf": [{ "enum": ["html", "json"] }, { "minLength": 1 }]
+    },
+    "name": {
+      "description": "Title of the documentation. (`workspaceDocs` uses workspace name as default - defined in `package.json`)",
+      "type": "string"
+    },
+    "includes": {
+      "description": "Path to external markdown files, folder should contain a summary.json. (`workspaceDocs` will override this)",
+      "type": "string"
+    },
+    "includesName": {
+      "description": "Name of menu item containing external markdown files. (workspaceDocs uses \"Projects\" as default)",
+      "type": "string"
+    },
+    "assetsFolder": {
+      "description": "External assets folder to copy in generated documentation folder.",
+      "type": "string"
+    },
+    "unitTestCoverage": {
+      "description": "Path to unit test coverage in json-summary format.",
+      "type": "string"
+    },
+    "disableCoverage": {
+      "description": "Do not add the documentation coverage report.",
+      "type": "boolean",
+      "default": true
+    },
+    "disableSourceCode": {
+      "description": "Do not add source code tab and links to source code.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableDomTree": {
+      "description": "Do not add dom tree tab.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableTemplateTab": {
+      "description": "Do not add template tab.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableStyleTab": {
+      "description": "Do not add style tab.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableGraph": {
+      "description": "Disable rendering of the dependency graph.",
+      "type": "boolean",
+      "default": false
+    },
+    "disablePrivate": {
+      "description": "Do not show private in generated documentation.",
+      "type": "boolean",
+      "default": true
+    },
+    "disableProtected": {
+      "description": "Do not show protected in generated documentation.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableInternal": {
+      "description": "Do not show @internal in generated documentation.",
+      "type": "boolean",
+      "default": true
+    },
+    "disableLifeCycleHooks": {
+      "description": "Do not show Angular lifecycle hooks in generated documentation.",
+      "type": "boolean",
+      "default": true
+    },
+    "disableRoutesGraph": {
+      "description": "Do not add the routes graph.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableSearch": {
+      "description": "Do not add the search input.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableDependencies": {
+      "description": "Do not add the dependencies list.",
+      "type": "boolean",
+      "default": false
+    },
+    "language": {
+      "description": "Language used for generated documentation.",
+      "type": "string",
+      "default": "en-US",
+      "anyOf": [
+        {
+          "enum": [
+            "en-US",
+            "de-DE",
+            "es-ES",
+            "fr-FR",
+            "hu-HU",
+            "it-IT",
+            "ja-JP",
+            "ko-KR",
+            "nl-NL",
+            "pl-PL",
+            "pt-BR",
+            "sk-SK",
+            "zh-CN"
+          ]
+        },
+        {
+          "minLength": 1
+        }
+      ]
+    },
+    "theme": {
+      "description": "Theme used for generated documentation.",
+      "type": "string",
+      "default": "gitbook",
+      "anyOf": [
+        {
+          "enum": [
+            "gitbook",
+            "laravel",
+            "original",
+            "material",
+            "postmark",
+            "readthedocs",
+            "stripe",
+            "vagrant"
+          ]
+        },
+        {
+          "minLength": 1
+        }
+      ]
+    },
+    "extTheme": {
+      "description": "Path to external theme file.",
+      "type": "string"
+    },
+    "templates": {
+      "description": "Path to directory of Handlebars templates to override built-in templates.",
+      "type": "string"
+    },
+    "customLogo": {
+      "description": "Path to custom logo.",
+      "type": "string"
+    },
+    "customFavicon": {
+      "description": "Path to custom favicon.",
+      "type": "string"
+    },
+    "hideGenerator": {
+      "description": "Do not print the Compodoc logo at the bottom of the page.",
+      "type": "boolean",
+      "default": false
+    },
+    "serve": {
+      "description": "Serve generated documentation.",
+      "type": "boolean"
+    },
+    "port": {
+      "description": "Port for serving of documentation. (default: 8080)",
+      "type": "number",
+      "default": 8080
+    },
+    "watch": {
+      "description": "Watch for source files changes to automatically rebuild documentation.",
+      "type": "boolean",
+      "default": false
+    },
+    "silent": {
+      "description": "Suppress verbose build output.",
+      "type": "boolean"
+    }
+  },
   "required": []
 }


### PR DESCRIPTION
- Rewrite compodoc executor based on Nrwl DevKit
- Add support for standalone project configurations - #46
- Use compodoc's internal watch mode for all export format (ensure required serve config in watch mode) - #47
- Add debug option to log resulting options & compodoc command