### PR TITLE
Enable correct watch mode for workspace docs #44

### DIFF
--- a/packages/compodoc/CHANGELOG.md
+++ b/packages/compodoc/CHANGELOG.md
@@ -29,7 +29,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 
 
-# [1.6.0](https://github.com/twittwer/nx-tools/compare/compodoc/v1.5.3...compodoc/v1.6.0) (2021-10-31)
+## [1.6.0](https://github.com/twittwer/nx-tools/compare/compodoc/v1.5.3...compodoc/v1.6.0) (2021-10-31)
 
 
 ### Bug Fixes


### PR DESCRIPTION
Wrap Compodoc in Nodemon for workspaceDocs as Compodoc's internal watch mode determines the wrong directory for watching for the broad includes in `tsconfig.compodoc.json`.