### PR TITLE
fix: remove name check for task runner

### DIFF
--- a/packages/compodoc/src/generators/compodoc/generator.ts
+++ b/packages/compodoc/src/generators/compodoc/generator.ts
@@ -60,10 +60,7 @@ function init(tree: Tree): GeneratorCallback {
   );
 
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
-  if (
-    workspaceConfiguration.tasksRunnerOptions?.default?.runner ===
-    '@nrwl/workspace/tasks-runners/default'
-  ) {
+  if (workspaceConfiguration.tasksRunnerOptions?.default) {
     workspaceConfiguration.tasksRunnerOptions.default.options =
       workspaceConfiguration.tasksRunnerOptions.default.options || {};
     workspaceConfiguration.tasksRunnerOptions.default.options.cacheableOperations =


### PR DESCRIPTION
Nx changed the namespace of the task runner from `@nrwl/workspace` to `nx`. To prevent future refactorings the check for the runner name was removed.