### PR TITLE
fix(compodoc): correct `coverageTest` behavior

### DIFF
--- a/packages/compodoc/README.md
+++ b/packages/compodoc/README.md
@@ -76,6 +76,7 @@ Additional options (used exclusively by the executor) are indicated by an italic
 | assetsFolder              |                                      | External assets folder to copy in generated documentation folder.                                                              |
 | unitTestCoverage          |                                      | Path to unit test coverage in json-summary format.                                                                             |
 |                           |                                      |                                                                                                                                |
+| disableCoverage           | `true`                               | Do not add the documentation coverage report.                                                                                  |
 | disableSourceCode         | `false`                              | Do not add source code tab and links to source code.                                                                           |
 | disableDomTree            | `false`                              | Do not add dom tree tab.                                                                                                       |
 | disableTemplateTab        | `false`                              | Do not add template tab.                                                                                                       |
@@ -89,8 +90,7 @@ Additional options (used exclusively by the executor) are indicated by an italic
 | disableSearch             | `false`                              | Do not add the search input.                                                                                                   |
 | disableDependencies       | `false`                              | Do not add the dependencies list.                                                                                              |
 |                           |                                      |                                                                                                                                |
-| disableCoverage           | `true`                               | Do not add the documentation coverage report.                                                                                  |
-| coverageTest              | `70` (`0` with disabled coverage)    | Test command of documentation coverage with a threshold.                                                                       |
+| coverageTest              | `0`                                  | Test command of documentation coverage with a threshold. Any value other than 0 disables documentation generation.             |
 | coverageMinimumPerFile    | `0`                                  | Test command of documentation coverage per file with a minimum.                                                                |
 | coverageTestThresholdFail | `true`                               | Test command of documentation coverage (global or per file) will fail with error or just warn user (true: error, false: warn). |
 |                           |                                      |                                                                                                                                |

--- a/packages/compodoc/src/executors/build/executor.ts
+++ b/packages/compodoc/src/executors/build/executor.ts
@@ -121,6 +121,8 @@ function toCompodocOptions(
     assetsFolder: toRelativePath(options.assetsFolder, ..._),
     unitTestCoverage: toRelativePath(options.unitTestCoverage, ..._),
 
+    // This must be disabled to run `coverageTest` (otherwise error).
+    disableCoverage: options.coverageTest ? false : options.disableCoverage,
     disableSourceCode: options.disableSourceCode,
     disableDomTree: options.disableDomTree,
     disableTemplateTab: options.disableTemplateTab,
@@ -134,8 +136,7 @@ function toCompodocOptions(
     disableSearch: options.disableSearch,
     disableDependencies: options.disableDependencies,
 
-    disableCoverage: options.disableCoverage,
-    coverageTest: options.disableCoverage ? 0 : options.coverageTest,
+    coverageTest: options.coverageTest,
     coverageTestThresholdFail: options.coverageTestThresholdFail,
     coverageMinimumPerFile: options.coverageMinimumPerFile,
 

--- a/packages/compodoc/src/executors/build/schema.d.ts
+++ b/packages/compodoc/src/executors/build/schema.d.ts
@@ -29,6 +29,8 @@ export interface CompodocOptions {
   assetsFolder?: string;
   unitTestCoverage?: string;
 
+  /** @default true */
+  disableCoverage: boolean;
   /** @default false */
   disableSourceCode: boolean;
   /** @default false */
@@ -54,9 +56,7 @@ export interface CompodocOptions {
   /** @default false */
   disableDependencies: boolean;
 
-  /** @default true */
-  disableCoverage: boolean;
-  /** @default 70 (0 with disabled coverage) */
+  /** @default 0 */
   coverageTest: number;
   /** @default 0 */
   coverageMinimumPerFile: number;

--- a/packages/compodoc/src/executors/build/schema.json
+++ b/packages/compodoc/src/executors/build/schema.json
@@ -52,6 +52,11 @@
       "description": "Path to unit test coverage in json-summary format.",
       "type": "string"
     },
+    "disableCoverage": {
+      "description": "Do not add the documentation coverage report.",
+      "type": "boolean",
+      "default": true
+    },
     "disableSourceCode": {
       "description": "Do not add source code tab and links to source code.",
       "type": "boolean",
@@ -112,15 +117,10 @@
       "type": "boolean",
       "default": false
     },
-    "disableCoverage": {
-      "description": "Do not add the documentation coverage report.",
-      "type": "boolean",
-      "default": true
-    },
     "coverageTest": {
       "description": "Test command of documentation coverage with a threshold",
       "type": "integer",
-      "default": 70,
+      "default": 0,
       "minimum": 0,
       "maximum": 100
     },


### PR DESCRIPTION
Hello @twittwer,

There was a misunderstanding in the previous implementation:
The `coverageTest` flag runs a "coverage test" and do not generate the documentation.
The `disableCoverage` removes the `Documentation coverage` page in the documentation (image).

> I'm also reversing the order of the flags, before https://github.com/twittwer/nx-tools/pull/83, as the two flags don't have the same (exact) category.

![image](https://github.com/twittwer/nx-tools/assets/37412330/d9d6d347-d5da-4605-ac1f-122aa79aaa11)
